### PR TITLE
feat: `TypeNavigator` and unified type search

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -213,7 +213,12 @@ export default class DocumentationCommand extends SlashCommand<ErisClient> {
       case 'class':
       case 'typedef': {
         const descriptor = TypeNavigator.findFirstMatch(options[calledType]) as ClassDescriptor | TypeDescriptor;
-        typeMeta = descriptor.meta;
+        try {
+          typeMeta = descriptor.meta;
+        } catch {
+          ctx.send('Entity was `null`, please check arguments.', { ephemeral: true });
+          return;
+        }
 
         Object.assign(embed, {
           title: `${descriptor.name}${'extends' in descriptor ? ` *extends \`${descriptor.extends.join('')}\`*` : ''}`,
@@ -226,12 +231,17 @@ export default class DocumentationCommand extends SlashCommand<ErisClient> {
       default: {
         if (options[calledType] === 'null') {
           // yes... litereal null
-          ctx.send('Invalid query.', { ephemeral: true });
+          ctx.send('Invalid query, please check arguments.', { ephemeral: true });
           return;
         }
 
         const typeEntry = TypeNavigator.findFirstMatch(options.class, options[calledType]) as ChildStructureDescriptor;
-        typeMeta = typeEntry.meta;
+        try {
+          typeMeta = typeEntry.meta;
+        } catch {
+          ctx.send('Entity was `null`, please check arguments.', { ephemeral: true });
+          return;
+        }
 
         const combinedKey = TypeNavigator.joinKey([options.class, options[calledType]], TypeSymbol[calledType]);
 

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,5 +1,4 @@
 import { Client as ErisClient } from 'eris';
-import fuzzy from 'fuzzy';
 import {
   SlashCommand,
   CommandOptionType,
@@ -17,17 +16,14 @@ import { SC_RED } from '../util/common';
 import { buildDocsLink, buildGitHubLink } from '../util/linkBuilder';
 import {
   AnyStructureDescriptor,
-  ChildStructureDescriptor,
   ClassDescriptor,
   EventDescriptor,
   MethodDescriptor,
-  TypeRoute,
   TypeSource,
   TypeSymbol
 } from '../util/metaTypes';
 import TypeNavigator from '../util/typeNavigator';
 
-import { typeMap, fetchMetadata } from '../util/typeResolution';
 
 export default class DocumentationCommand extends SlashCommand<ErisClient> {
   constructor(creator: SlashCreator) {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -225,7 +225,7 @@ export default class DocumentationCommand extends SlashCommand<ErisClient> {
           fields: this.getClassEntityFields(descriptor)
         });
 
-        fragments.push(descriptor.name);
+        fragments[0] = descriptor.name;
         break;
       }
       default: {
@@ -262,7 +262,8 @@ export default class DocumentationCommand extends SlashCommand<ErisClient> {
           });
 
         // exact check, if typeEntry were a class i'd do instance of... maybe
-        fragments.push((calledType === 'event' ? 'e-' : '') + options[calledType]);
+        fragments[0] = options.class;
+        fragments[1] = (calledType === 'event' ? 'e-' : '') + options[calledType];
       }
     }
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,10 +1,17 @@
 import { Client as ErisClient } from 'eris';
-import { AutocompleteChoice, AutocompleteContext, CommandContext, CommandOptionType, SlashCommand } from 'slash-create';
+import {
+  AutocompleteChoice,
+  AutocompleteContext,
+  CommandContext,
+  CommandOptionType,
+  SlashCommand,
+  SlashCreator
+} from 'slash-create';
 
 import TypeNavigator from '../util/typeNavigator';
 
 export default class SearchCommand extends SlashCommand<ErisClient> {
-  constructor(creator) {
+  constructor(creator: SlashCreator) {
     super(creator, {
       name: 'search',
       description: 'Search for a documentation entry.',

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,7 @@
 import { Client as ErisClient } from 'eris';
 import { AutocompleteChoice, AutocompleteContext, CommandContext, CommandOptionType, SlashCommand } from 'slash-create';
-import { filter as fuzzyFilter } from 'fuzzy';
-import { typeMap } from '../util/typeResolution';
+
+import TypeNavigator from '../util/typeNavigator';
 
 export default class SearchCommand extends SlashCommand<ErisClient> {
   constructor(creator) {
@@ -21,16 +21,11 @@ export default class SearchCommand extends SlashCommand<ErisClient> {
   }
 
   async autocomplete(ctx: AutocompleteContext): Promise<AutocompleteChoice[]> {
-    const { query } = ctx.options;
+    const { query } = ctx.options as { query: string };
 
-    const queryResults = fuzzyFilter(query, Object.keys(typeMap.all));
+    const results = TypeNavigator.fuzzyFilter([query]);
 
-    return queryResults
-      .map((entry) => ({
-        name: `${entry.string} {score: ${entry.score}}`,
-        value: entry.string
-      }))
-      .slice(0, 25);
+    return results.map((entry) => ({ name: entry, value: entry }));
   }
 
   async run(ctx: CommandContext): Promise<string> {
@@ -39,7 +34,7 @@ export default class SearchCommand extends SlashCommand<ErisClient> {
     const { query } = ctx.options;
 
     const [, first, second] = query.match(/(\w+)[#~$](\w+)/);
-    const subtype = typeMap.all[query];
+    const subtype = TypeNavigator.typeMap.all[query];
 
     return [
       `You selected \`${query}\`, this is not a entry retrieval command.`,

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -23,9 +23,9 @@ export default class SearchCommand extends SlashCommand<ErisClient> {
   async autocomplete(ctx: AutocompleteContext): Promise<AutocompleteChoice[]> {
     const { query } = ctx.options as { query: string };
 
-    const results = TypeNavigator.fuzzyFilter([query]);
+    const results = TypeNavigator.fuzzyFilter(query);
 
-    return results.map((entry) => ({ name: entry, value: entry }));
+    return results.map((entry) => ({ name: `${entry.string} {score: ${entry.score}}`, value: entry.string }));
   }
 
   async run(ctx: CommandContext): Promise<string> {

--- a/src/util/linkBuilder.ts
+++ b/src/util/linkBuilder.ts
@@ -4,7 +4,7 @@ export const BRANCH = `master`; // possiblity to add branch support further in, 
 export const BASE_DOCS_URL = `https://slash-create.js.org/#/docs/main/${BRANCH}`;
 export const BASE_GITHUB_URL = `https://github.com/Snazzah/slash-create/blob/${BRANCH}`;
 
-export function buildDocsLink(calledType: string, entity: string, scrollTo: string) {
+export function buildDocsLink(calledType: string, entity: string, scrollTo?: string) {
   return `${BASE_DOCS_URL}/${calledType}/${entity}${scrollTo ? `?scrollTo=${scrollTo}` : ''}`;
 }
 

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -89,10 +89,22 @@ export enum TypeSymbol {
   event = '$'
 }
 
+export enum TypeSource {
+  method = 'method',
+  prop = 'prop',
+  event = 'event'
+}
+
 export enum TypeRoute {
   method = 'methods',
   prop = 'props',
   event = 'events'
+}
+
+export interface TypeOutcome {
+  method: MethodDescriptor;
+  prop: MemberDescriptor;
+  event: EventDescriptor;
 }
 
 export type ChildStructureDescriptor = MethodDescriptor | MemberDescriptor | EventDescriptor;

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -85,7 +85,7 @@ export interface TypeDescriptor {
 
 export enum TypeSymbol {
   method = '#',
-  member = '~',
+  prop = '~',
   event = '$'
 }
 

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -48,6 +48,7 @@ export interface FileMeta {
 
 export interface MethodDescriptor {
   deprecated: boolean;
+  description: string;
   access?: 'private';
   emits: []; // unknown
   examples: []; // unknown

--- a/src/util/typeNavigator.ts
+++ b/src/util/typeNavigator.ts
@@ -1,0 +1,153 @@
+import bent from 'bent';
+import { simpleFilter } from 'fuzzy';
+
+import { AnyStructureDescriptor, DocumentationRoot } from './metaTypes';
+
+const getJSON = bent('json');
+const exclusionRegex = /(?:^_|\[|\])/;
+const targetURI = 'https://raw.githubusercontent.com/Snazzah/slash-create/docs/latest.json';
+
+interface TypeMap {
+  class: { [className: string]: number };
+  event: { [eventName: string]: [classIndex: number, eventIndex: number] };
+  method: { [methodKey: string]: [number, number] };
+  prop: { [memberKey: string]: [number, number] };
+  typedef: { [typeName: string]: number };
+  all: { [keyName: string]: Exclude<keyof TypeMap, 'all'> };
+}
+
+export default class TypeNavigator {
+  constructor() {
+    throw new Error('TypeNavigator is a static class.');
+  }
+
+  static indexSymbol = Symbol('index');
+  static data: DocumentationRoot;
+  static typeMap: TypeMap;
+
+  static knownSymbols = ['#', '~', '$'];
+
+  static get classes() {
+    return this.data.classes;
+  }
+
+  static get meta() {
+    return this.data.meta;
+  }
+
+  static getClassDescriptor(className: string) {
+    const classIndex = this.typeMap.class[className];
+    return this.classes[classIndex];
+  }
+
+  static getMethodDescriptor(className: string, methodName: string) {
+    const [classIndex, methodIndex] = this.typeMap.method[`${className}#${methodName}`];
+    return this.classes[classIndex].methods[methodIndex];
+  }
+
+  static getEventDescriptor(className: string, eventName: string) {
+    const [classIndex, eventIndex] = this.typeMap.event[`${className}$${eventName}`];
+    return this.classes[classIndex].events[eventIndex];
+  }
+
+  static getPropDescriptor(className: string, propName: string) {
+    const [classIndex, propIndex] = this.typeMap.prop[`${className}~${propName}`];
+    return this.classes[classIndex].props[propIndex];
+  }
+
+  static getTypeDescriptor(typeName: string) {
+    const typeIndex = this.typeMap.typedef[typeName];
+    return this.data.typedefs[typeIndex];
+  }
+
+  static findFirstMatch(className: string, typeName?: string): AnyStructureDescriptor {
+    for (const connector of this.knownSymbols) {
+      const assumedKey = [className, typeName].join(connector);
+      const entityType = this.typeMap.all[assumedKey];
+
+      switch (entityType) {
+        case undefined:
+        case null:
+          continue;
+        case 'class':
+          return this.getClassDescriptor(className);
+        case 'event':
+          return this.getEventDescriptor(className, typeName);
+        case 'method':
+          return this.getMethodDescriptor(className, typeName);
+        case 'prop':
+          return this.getPropDescriptor(className, typeName);
+        case 'typedef':
+          return this.getTypeDescriptor(className);
+      }
+    }
+
+    return undefined;
+  }
+
+  static fuzzyFilter = (entityPath: string[], typeFilter: keyof TypeMap = 'all', limit: number = 25) =>
+    simpleFilter(entityPath.join('*'), Object.keys(this.typeMap[typeFilter])).slice(0, limit);
+
+  static {
+    getJSON(targetURI).then((doc: DocumentationRoot) => {
+      this.data = doc;
+      this.generateTypeMap();
+    });
+  }
+
+  static generateTypeMap() {
+    this.typeMap = {
+      class: {},
+      event: {},
+      method: {},
+      typedef: {},
+      prop: {},
+      all: {}
+    };
+
+    for (const [classIndex, classEntry] of this.data.classes.entries()) {
+      // console.log(`[Class] ${classEntry.name} at ${classIndex}`);
+      this.typeMap.class[classEntry.name] = classIndex;
+      this.typeMap.all[classEntry.name] = 'class';
+
+      if (classEntry.events) {
+        for (const [eventIndex, eventEntry] of classEntry.events.entries()) {
+          const key = `${classEntry.name}$${eventEntry.name}`;
+          // console.log(`[Event] ${key} at ${eventIndex}`);
+          this.typeMap.event[key] = [classIndex, eventIndex];
+          this.typeMap.all[key] = 'event';
+        }
+      }
+
+      if (classEntry.methods) {
+        for (const [methodIndex, methodEntry] of classEntry.methods.entries()) {
+          const shouldSkip = exclusionRegex.test(methodEntry.name);
+          const key = `${classEntry.name}#${methodEntry.name}`;
+          // console.log(`[Method] ${key} at ${methodIndex}  ${shouldSkip ? ', Skipping...' : ''}`);
+          if (!shouldSkip) {
+            this.typeMap.method[key] = [classIndex, methodIndex];
+            this.typeMap.all[key] = 'method';
+          }
+        }
+      }
+
+      if (classEntry.props) {
+        for (const [propIndex, propEntry] of classEntry.props.entries()) {
+          const shouldSkip = exclusionRegex.test(propEntry.name);
+          const key = `${classEntry.name}~${propEntry.name}`;
+          // console.log(`[Member] ${key} at ${propIndex} ${shouldSkip ? ', Skipping...' : ''}`);
+          if (!shouldSkip) {
+            this.typeMap.prop[key] = [classIndex, propIndex];
+            this.typeMap.all[key] = 'prop';
+          }
+        }
+      }
+    }
+
+    for (const [typeIndex, typeEntry] of this.data.typedefs.entries()) {
+      // console.log(`[Type] ${typeEntry.name} at ${typeIndex}`);
+      this.typeMap.typedef[typeEntry.name] = typeIndex;
+      this.typeMap.all[typeEntry.name] = 'typedef';
+    }
+  }
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,4 @@
+import { User as ErisUser } from 'eris';
+import { User as SlashUser } from 'slash-create';
+
+export type User = ErisUser | SlashUser;


### PR DESCRIPTION
This change achieves full functionality for what it is intended to do.

- If a child descriptor is queried before a class, the literal of `'null'` is returned in autocomplete
  If it remains when running the command, it will forcefully return.
  > This *could* be more descriptive in the future by suggesting the user to run `/docs class class: {classQuery}` but is functional for now to the point that common sense should figure out the rest.

Changes still yet to be made under consideration of accuracy:
- [Search scores](#diff-eaac47180721aa98a21f807bd79283c72a8f696d3cb0cd0fac4d93cfd83dd72dR188) are still included in autocomplete for child descriptors
- Inaccuracies with entity selection in child descriptors (after class has been selected, namely `SlashCreator` and `SlashCreatorAPI`).
- Entities of `/docs typedef ...` are not queried when using `/docs prop ...`, this is limited to entities of `/docs class ...` only.

<details>
<summary>Showcase (3 media items)</summary>

*Iteration 1: has remained for typedefs*
![image](https://user-images.githubusercontent.com/8607699/179353386-bc173436-0fc5-408c-9797-bffc19ff4259.png)

*Iteration 2: class structures only*
![image](https://user-images.githubusercontent.com/8607699/179355028-871a02e2-9a8d-4414-9453-728c48b10e25.png)

https://user-images.githubusercontent.com/8607699/179353887-7179b9ff-a0d7-41b0-bd1f-a8483e1ae59c.mp4
</details>

> Translation / Locale support is *a possibility* but primarily focusing on the link buttons and the command localization within the framework itself, rather than jumbling the mess that is the documentation structure. That doesn't mean it'll be implemented, but it'd be utilizing the infrastructure provided by the framework *including [`SlashCommand#onLocaleUpdate`](https://slash-create.js.org/#/docs/main/master/class/null)*.