### PR TITLE
Move service to web endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "bent": "^7.3.12",
     "cat-loggr": "^1.1.0",
     "dotenv": "^8.2.0",
-    "eris": "^0.17.1",
-    "fastify": "^3.9.2",
+    "fastify": "^4.2.1",
     "fuzzy": "^0.1.3",
     "slash-create": "^5.7.0"
   },

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -245,7 +245,7 @@ export default class DocumentationCommand extends SlashCommand {
         const combinedKey = TypeNavigator.joinKey([options.class, options[calledType]], TypeSymbol[calledType]);
 
         Object.assign(embed, {
-          title: `${combinedKey}`,
+          title: combinedKey,
           description: typeEntry.description
         });
 

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,4 +1,3 @@
-import { Client as ErisClient } from 'eris';
 import {
   AutocompleteChoice,
   AutocompleteContext,
@@ -28,7 +27,7 @@ import {
 } from '../util/metaTypes';
 import TypeNavigator from '../util/typeNavigator';
 
-export default class DocumentationCommand extends SlashCommand<ErisClient> {
+export default class DocumentationCommand extends SlashCommand {
   constructor(creator: SlashCreator) {
     super(creator, {
       name: 'docs',

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -190,7 +190,7 @@ export default class DocumentationCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext): Promise<MessageOptions | string | void> {
-    if (!this.ids.has('global')) this.ids.set('global', ctx.commandID);
+    // if (!this.ids.has('global')) this.ids.set('global', ctx.commandID);
 
     const calledType = ctx.subcommands[0];
     const options = ctx.options[calledType];

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,4 +1,3 @@
-import { Client as ErisClient } from 'eris';
 import {
   AutocompleteChoice,
   AutocompleteContext,
@@ -10,7 +9,7 @@ import {
 
 import TypeNavigator from '../util/typeNavigator';
 
-export default class SearchCommand extends SlashCommand<ErisClient> {
+export default class SearchCommand extends SlashCommand {
   constructor(creator: SlashCreator) {
     super(creator, {
       name: 'search',

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,7 @@ creator.on('commandError', (command, error) => logger.error(`Command ${command.c
 creator
   .withServer(new FastifyServer())
   .registerCommandsIn(path.join(__dirname, 'commands'))
-  .startServer();
+  .collectCommandIDs()
+  .then(() => {
+    creator.startServer();
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,12 @@ if (path.parse(process.cwd()).name === 'dist') dotenvPath = path.join(process.cw
 dotenv.config({ path: dotenvPath });
 
 const logger = new CatLoggr().setLevel(process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info');
-const client = new ErisClient(process.env.DISCORD_BOT_TOKEN);
 const creator = new SlashCreator({
   applicationID: process.env.DISCORD_APP_ID,
   publicKey: process.env.DISCORD_PUBLIC_KEY,
   token: process.env.DISCORD_BOT_TOKEN,
   serverPort: parseInt(process.env.PORT, 10) || 8020,
-  serverHost: '0.0.0.0',
-  client
+  serverHost: '0.0.0.0'
 });
 
 creator.on('debug', (message) => logger.log(message));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv';
-import { SlashCreator, GatewayServer } from 'slash-create';
-import { Client as ErisClient } from 'eris';
+import { SlashCreator, FastifyServer } from 'slash-create';
 import path from 'path';
 import CatLoggr from 'cat-loggr/ts';
 
@@ -30,18 +29,8 @@ creator.on('commandRun', (command, _, ctx) =>
 creator.on('commandRegister', (command) => logger.info(`Registered command ${command.commandName}`));
 creator.on('commandError', (command, error) => logger.error(`Command ${command.commandName}:`, error));
 
+// eslint-disable-next-line prettier/prettier
 creator
-  .withServer(
-    new GatewayServer((handler) => {
-      client.on('rawWS', (packet: any) => {
-        if (packet.t === 'INTERACTION_CREATE') {
-          handler(packet.d);
-        }
-      });
-    })
-  )
-  // .startServer()
-  .registerCommandsIn(path.join(__dirname, 'commands'));
-
-// console.log(`Starting server at "localhost:${creator.options.serverPort}/interactions"`);
-client.connect();
+  .withServer(new FastifyServer())
+  .registerCommandsIn(path.join(__dirname, 'commands'))
+  .startServer();

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,4 +1,0 @@
-import { User as ErisUser } from 'eris';
-import { User as SlashUser } from 'slash-create';
-
-export type User = ErisUser | SlashUser;


### PR DESCRIPTION
This exchanges `eris` with `fastify` as the provider for interaction requests. In doing so, also changes this application's dependence from the gateway to a web-based endpoint. In the immediate sense, there is nothing more to do - however serverless deployment may require some... considerations to improve expected lag time (i.e. requesting the docgen manifest and running `SlashCreator#collectCommandIDs()` on each run - both time consuming, and likely to hit a rate limit with increased activity).