### PR TITLE
patch... again, wrong index target

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -42,7 +42,7 @@ export default class SearchCommand extends SlashCommand {
 
     const command = ['/docs', subtype, `${subtype}: ${second || first}`];
 
-    if (second) command.splice(1, 0, 'class');
+    if (second) command.splice(2, 0, `class: ${first}`);
 
     ctx.send(
       [


### PR DESCRIPTION
If any child descriptor were selected with this command this is the resulting change:
> `/docs class {type} {type}: {second}` -> `/docs {type} class: {first} {type}: {second}`

Personally, array splicing with 0 removals being used as a `push()` or `unshift()` is much easier than having to handle an if/else which would use another two lines with statement braces.