### PR TITLE
feat: type resolution

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -135,7 +135,7 @@ export default class DocumentationCommand extends SlashCommand {
 
     switch (ctx.focused) {
       case 'class': {
-        let matchingKeys = TypeNavigator.fuzzyFilter(focusedOption, 'class', 25);
+        let matchingKeys = TypeNavigator.fuzzyFilter(focusedOption, 'class');
 
         if (command === 'event')
           matchingKeys = matchingKeys.filter((value) => 'events' in TypeNavigator.getClassDescriptor(value.string));

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -252,7 +252,7 @@ export default class DocumentationCommand extends SlashCommand {
         if ('type' in typeEntry)
           embed.fields.push({
             name: 'Type',
-            value: `${this.resolveType(typeEntry.type)}`
+            value: this.resolveType(typeEntry.type)
           });
 
         if ('params' in typeEntry)
@@ -263,7 +263,7 @@ export default class DocumentationCommand extends SlashCommand {
           // calledType === 'method'
           embed.fields.push({
             name: 'Returns',
-            value: `${this.resolveType(typeEntry.returns)}`
+            value: this.resolveType(typeEntry.returns)
           });
 
         // exact check, if typeEntry were a class i'd do instance of... maybe
@@ -274,18 +274,22 @@ export default class DocumentationCommand extends SlashCommand {
 
     return {
       embeds: [embed],
-      components: this.getLinkComponents(fragments, typeMeta)
+      components: this.getLinkComponents(fragments, typeMeta, calledType === 'typedef')
     };
   }
 
-  private getLinkComponents = (target: [string, string?], typeMeta: FileMeta): ComponentActionRow[] => [
+  private getLinkComponents = (
+    target: [string, string?],
+    typeMeta: FileMeta,
+    isTypedef: boolean
+  ): ComponentActionRow[] => [
     {
       type: ComponentType.ACTION_ROW,
       components: [
         {
           type: ComponentType.BUTTON,
           style: ButtonStyle.LINK,
-          url: buildDocsLink('class', ...target),
+          url: buildDocsLink(isTypedef ? 'typedef' : 'class', ...target),
           label: 'Open Docs',
           emoji: {
             name: '📕'

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -221,6 +221,7 @@ export default class DocumentationCommand extends SlashCommand {
 
         Object.assign(embed, {
           title: `${descriptor.name}${'extends' in descriptor ? ` *extends \`${descriptor.extends.join('')}\`*` : ''}`,
+          description: descriptor.description,
           fields: this.getClassEntityFields(descriptor, 'construct' in descriptor)
         });
 

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -13,9 +13,10 @@ import {
   SlashCreator
 } from 'slash-create';
 
-import { SC_RED } from '../util/common';
+import { SC_RED, titleCase } from '../util/common';
 import { buildDocsLink, buildGitHubLink } from '../util/linkBuilder';
 import {
+  CallableDescriptor,
   ChildStructureDescriptor,
   ClassDescriptor,
   EventDescriptor,
@@ -258,7 +259,7 @@ export default class DocumentationCommand extends SlashCommand {
 
         if ('params' in typeEntry)
           // calledType !== 'prop'
-          embed.fields.push(...this.getArgumentEntityFields(typeEntry));
+          embed.fields.push(...this.getArgumentEntityFields(typeEntry, calledType));
 
         if ('returns' in typeEntry)
           // calledType === 'method'
@@ -305,13 +306,13 @@ export default class DocumentationCommand extends SlashCommand {
     }
   ];
 
-  private getArgumentEntityFields = (argumentParent: MethodDescriptor | EventDescriptor): EmbedField[] => {
+  private getArgumentEntityFields = (argumentParent: CallableDescriptor, entityType: string): EmbedField[] => {
     const { params } = argumentParent;
 
     if (!params.length) return [];
 
     return params.map((argument, index) => ({
-      name: !index ? 'Arguments' : '\u200b',
+      name: index === 0 ? `${titleCase(entityType)} Arguments` : '\u200b',
       value: [
         `\`${argument.name}\` - ${this.resolveType(argument.type)} ${
           argument.default ? `= ${argument.default}` : ''

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -3,6 +3,7 @@ import {
   AutocompleteContext,
   CommandContext,
   CommandOptionType,
+  MessageOptions,
   SlashCommand,
   SlashCreator
 } from 'slash-create';
@@ -40,7 +41,7 @@ export default class SearchCommand extends SlashCommand {
     return results.map((entry) => ({ name: `${entry.string} {score: ${entry.score}}`, value: entry.string }));
   }
 
-  async run(ctx: CommandContext): Promise<void> {
+  async run(ctx: CommandContext): Promise<MessageOptions> {
     const { query } = ctx.options as { query: string };
 
     const [first, second = ''] = query.split(/[#$~]/);
@@ -50,13 +51,13 @@ export default class SearchCommand extends SlashCommand {
 
     if (second) command.splice(2, 0, `class: ${first}`);
 
-    ctx.send(
-      [
+    return {
+      ephemeral: true,
+      content: [
         `You selected \`${query}\`, this is not a entry retrieval command.`,
         '*Entries found in this command may include internal structures not included on the primary command.*',
         `> Please use \`${command.join(' ')}\` - </docs ${subtype}:${this.docsCommand.ids.get('global')}>.`
-      ].join('\n'),
-      { ephemeral: true }
-    );
+      ].join('\n')
+    };
   }
 }

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,1 +1,4 @@
 export const SC_RED = 15929905; // color for #F31231
+
+export const titleCase = (input: string) => input.charAt(0).toUpperCase() + input.slice(1);
+

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -2,3 +2,29 @@ export const SC_RED = 15929905; // color for #F31231
 
 export const titleCase = (input: string) => input.charAt(0).toUpperCase() + input.slice(1);
 
+export const standardObjects = {
+  Object: 'Object',
+  [typeof {}]: 'Object',
+  Function: 'Function',
+  [typeof function () {}]: 'Function',
+  Boolean: 'Boolean',
+  [typeof true]: 'Boolean',
+  Symbol: 'Symbol',
+  [typeof Symbol()]: 'Symbol',
+  Error: 'Error',
+  RangeError: 'RangeError',
+  SyntaxError: 'SyntaxError',
+  TypeError: 'TypeError',
+  Number: 'Number',
+  [typeof Infinity]: 'Number',
+  BigInt: 'BigInt',
+  [typeof 1337n]: 'BigInt',
+  Date: 'Date',
+  String: 'String',
+  [typeof 'slash-create']: 'String',
+  RegExp: 'RegExp',
+  Array: 'Array',
+  Map: 'Map',
+  Set: 'Set',
+  Promise: 'Promise'
+};

--- a/src/util/linkBuilder.ts
+++ b/src/util/linkBuilder.ts
@@ -3,6 +3,7 @@ import { FileMeta } from './metaTypes';
 export const BRANCH = `master`; // possiblity to add branch support further in, but i wouldn't see much point if discord keeps changing stuff...
 export const BASE_DOCS_URL = `https://slash-create.js.org/#/docs/main/${BRANCH}`;
 export const BASE_GITHUB_URL = `https://github.com/Snazzah/slash-create/blob/${BRANCH}`;
+export const BASE_MDN_URL = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects`;
 
 export function buildDocsLink(calledType: string, entity: string, scrollTo?: string) {
   return `${BASE_DOCS_URL}/${calledType}/${entity}${scrollTo ? `?scrollTo=${scrollTo}` : ''}`;

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -110,3 +110,4 @@ export interface TypeOutcome {
 
 export type ChildStructureDescriptor = MethodDescriptor | MemberDescriptor | EventDescriptor;
 export type AnyStructureDescriptor = ChildStructureDescriptor | ClassDescriptor | TypeDescriptor;
+export type CallableDescriptor = MethodDescriptor | EventDescriptor | ClassConstructor;


### PR DESCRIPTION
This is functional for both internal documentation, and a limited number of entries on MDN known to be contained within the docgen manifest. Brace replacement is also fully functional with the forced escape sequence and having it join together for Discord to safely render it. - 9dd8b974c8dc1355445b220b4602e214bda1d96f

In addition to that...

- 815b26748736d6116418ec8fefd36818fabcd5e4 now uses default limit for fuzzy filtering on class autocompletion.
- 067723e8ff8743eb62cf906ce628a849839e72b3 *finally* adds a description for the parent structures.
- 55a3337f7e61088c0e1657bf4fd33658c2c0d958 `getArgumentEntityFields` now accepts an `entityType` argument.
  > This was intended for class constructors, but the spacing and layout of the resulting embed became a concern, so it was commented out for classes specifically. - Still there, it just won't show for now until another opportunity arises to improve its structure.