### PR TITLE
feat: add share option + cleanup option footprint

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -13,7 +13,7 @@ import {
   SlashCreator
 } from 'slash-create';
 
-import { SC_RED } from '../util/common';
+import { SC_RED, docsOptionFactory, shareOption } from '../util/common';
 import { buildDocsLink, buildGitHubLink } from '../util/linkBuilder';
 import {
   ChildStructureDescriptor,
@@ -38,92 +38,31 @@ export default class DocumentationCommand extends SlashCommand {
           name: 'class',
           description: 'Get entry for a class.',
           type: CommandOptionType.SUB_COMMAND,
-          options: [
-            {
-              name: 'class',
-              description: 'The class to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            }
-          ]
+          options: [docsOptionFactory('class'), shareOption]
         },
         {
           name: 'event',
-          description: 'The event to retrieve.',
+          description: 'Get entry for an event.',
           type: CommandOptionType.SUB_COMMAND,
-          options: [
-            {
-              name: 'class',
-              description: 'The class to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            },
-            {
-              name: 'event',
-              description: 'The event to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            }
-          ]
+          options: [docsOptionFactory('class'), docsOptionFactory('event'), shareOption]
         },
         {
           name: 'method',
           type: CommandOptionType.SUB_COMMAND,
           description: 'Get entry for a method.',
-          options: [
-            {
-              name: 'class',
-              description: 'The class to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            },
-            {
-              name: 'method',
-              description: 'The method to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            }
-          ]
+          options: [docsOptionFactory('class'), docsOptionFactory('method'), shareOption]
         },
         {
           name: 'prop',
           description: 'Get entry for a class prop.',
           type: CommandOptionType.SUB_COMMAND,
-          options: [
-            {
-              name: 'class',
-              description: 'The class to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            },
-            {
-              name: 'prop',
-              description: 'The prop to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            }
-          ]
+          options: [docsOptionFactory('class'), docsOptionFactory('prop'), shareOption]
         },
         {
           name: 'typedef',
           description: 'Get entry for a type definition.',
           type: CommandOptionType.SUB_COMMAND,
-          options: [
-            {
-              name: 'typedef',
-              description: 'The type to retrieve.',
-              type: CommandOptionType.STRING,
-              required: true,
-              autocomplete: true
-            }
-          ]
+          options: [docsOptionFactory('typedef'), shareOption]
         }
       ]
     });
@@ -199,10 +138,12 @@ export default class DocumentationCommand extends SlashCommand {
       color: SC_RED,
       fields: [],
       timestamp: new Date(ctx.invokedAt),
-      footer: {
-        text: `Requested by ${ctx.user.username}#${ctx.user.discriminator}`,
-        icon_url: ctx.user.avatarURL
-      }
+      ...(options.share && {
+        footer: {
+          text: `Requested by ${ctx.user.username}#${ctx.user.discriminator}`,
+          icon_url: ctx.user.avatarURL
+        }
+      })
     };
 
     const fragments: [string, string?] = [null, null];
@@ -274,7 +215,8 @@ export default class DocumentationCommand extends SlashCommand {
 
     return {
       embeds: [embed],
-      components: this.getLinkComponents(fragments, typeMeta)
+      components: this.getLinkComponents(fragments, typeMeta),
+      ephemeral: !options.share
     };
   }
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,1 +1,18 @@
+import { ApplicationCommandOption, ApplicationCommandOptionAutocompletable, CommandOptionType } from 'slash-create';
+
 export const SC_RED = 15929905; // color for #F31231
+
+export const shareOption: ApplicationCommandOption = {
+  type: CommandOptionType.BOOLEAN,
+  name: 'share',
+  description: 'Share the outcome of your query to the channel.',
+  required: false
+};
+
+export const docsOptionFactory = (option: string): ApplicationCommandOptionAutocompletable => ({
+  name: option,
+  description: `The ${option} to retrieve.`,
+  type: CommandOptionType.STRING,
+  required: true,
+  autocomplete: true
+});


### PR DESCRIPTION
* footer is not shown on ephemeral responses - `=false`
* to post to a channel for others to see option must be set to `true`, null is also considered false as a default for commands run without it

![image](https://user-images.githubusercontent.com/8607699/179607767-421fa58e-1adb-4a67-850f-cb5f4845c3ef.png)
