### PR TITLE
feat: `/code` command

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -165,7 +165,7 @@ export default class CodeCommand extends SlashCommand {
       endLine = lines.length;
     }
 
-    if (startLine <= 0) startLine = 0;
+    if (startLine <= 1) startLine = 1;
 
     const lineSelection = lines.slice(startLine - 1, endLine);
 

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -17,8 +17,6 @@ import { buildGitHubLink, rawContentLink } from '../util/linkBuilder';
 import TypeNavigator from '../util/typeNavigator';
 
 export default class CodeCommand extends SlashCommand {
-  offset = 50;
-
   constructor(creator: SlashCreator) {
     super(creator, {
       name: 'code',
@@ -60,13 +58,12 @@ export default class CodeCommand extends SlashCommand {
     let endLine = meta.line + this.offset;
 
     if (endLine > lines.length) {
-      startLine -= endLine - this.offset;
+      startLine -= endLine - startLine;
       endLine = lines.length;
     }
 
     if (startLine <= 0) startLine = 0;
 
-    const lineOffset = meta.line + this.offset;
     const lineSelection = lines.slice(startLine, endLine);
 
     let content = [

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -1,0 +1,111 @@
+import bent from 'bent';
+
+const getText = bent('string');
+
+import {
+  AutocompleteChoice,
+  AutocompleteContext,
+  ButtonStyle,
+  CommandContext,
+  CommandOptionType,
+  ComponentType,
+  MessageOptions,
+  SlashCommand,
+  SlashCreator
+} from 'slash-create';
+import { buildGitHubLink, rawContentLink } from '../util/linkBuilder';
+import TypeNavigator from '../util/typeNavigator';
+
+export default class CodeCommand extends SlashCommand {
+  offset = 50;
+
+  constructor(creator: SlashCreator) {
+    super(creator, {
+      name: 'code',
+      description: 'Get a section of code from the source repository.',
+      options: [
+        {
+          name: 'query',
+          description: 'The query to search all entries.',
+          type: CommandOptionType.STRING,
+          autocomplete: true,
+          required: true
+        }
+      ]
+    });
+  }
+
+  autocomplete = async ({ options }: AutocompleteContext): Promise<AutocompleteChoice[]> =>
+    TypeNavigator.fuzzyFilter(options.query as string).map<AutocompleteChoice>((entry) => ({
+      name: `${entry.string} {score: ${entry.score}}`,
+      value: entry.string
+    }));
+
+  async run(ctx: CommandContext): Promise<MessageOptions | void | string> {
+    const { query } = ctx.options;
+
+    if (!(query in TypeNavigator.typeMap.all)) {
+      return {
+        content: 'Symbol not found',
+        ephemeral: true
+      };
+    }
+
+    const { meta } = TypeNavigator.findFirstMatch(query);
+    const file = `${meta.path}/${meta.file}`;
+    const res: string = await getText(`${rawContentLink}/${file}`);
+
+    const lines = res.split('\n');
+    let startLine = meta.line - 1; // slice offset
+    let endLine = meta.line + this.offset;
+
+    if (endLine > lines.length) {
+      startLine -= endLine - this.offset;
+      endLine = lines.length;
+    }
+
+    if (startLine <= 0) startLine = 0;
+
+    const lineOffset = meta.line + this.offset;
+    const lineSelection = lines.slice(startLine, endLine);
+
+    let content = [
+      `\`${file}\` - Lines \`${startLine + 1}\` to \`${endLine}\``,
+      '```js',
+      lineSelection
+        .map((line, index) => `/* ${`${startLine + index + 1}`.padStart(`${endLine}`.length, ' ')} */ ${line}`)
+        .join('\n'),
+      '```'
+    ].join('\n');
+
+    let actualEnd = lineOffset;
+
+    while (content.length > 2000) {
+      const lines = content.split('\n');
+      lines.splice(-2, 1);
+      actualEnd--;
+      lines[0] = `\`${file}\` - Lines \`${startLine + 1}\` to ~~\`${endLine}\`~~ \`${actualEnd}\``;
+      content = lines.join('\n');
+    }
+
+    ctx.send({
+      content,
+      components: [
+        {
+          type: ComponentType.ACTION_ROW,
+          components: [
+            {
+              type: ComponentType.BUTTON,
+              style: ButtonStyle.LINK,
+              url: buildGitHubLink(meta),
+              label: 'Open GitHub',
+              emoji: {
+                name: '📂'
+              }
+            }
+          ]
+        }
+      ]
+    });
+  }
+}

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -1,7 +1,4 @@
-import bent from 'bent';
 import { filter as fuzzyFilter } from 'fuzzy';
-
-const getText = bent('string');
 
 import {
   AutocompleteChoice,
@@ -14,7 +11,8 @@ import {
   SlashCommand,
   SlashCreator
 } from 'slash-create';
-import { buildGitHubLink, rawContentLink } from '../util/linkBuilder';
+import fileCache from '../util/fileCache';
+import { buildGitHubLink } from '../util/linkBuilder';
 import TypeNavigator from '../util/typeNavigator';
 
 export default class CodeCommand extends SlashCommand {
@@ -146,8 +144,8 @@ export default class CodeCommand extends SlashCommand {
       }
     }
 
-    const res: string = await getText(`${rawContentLink}/${file}`);
-    const lines = res.split('\n');
+    const { body } = await fileCache.fetch(file, 'master');
+    const lines = body.split('\n');
 
     if (startLine > lines.length) {
       return {

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -118,8 +118,10 @@ export default class CodeCommand extends SlashCommand {
 
         const { meta } = TypeNavigator.findFirstMatch(query);
 
-        startLine = meta.line - around - 1;
-        endLine = meta.line + around;
+        const buffer = Math.floor(around / 2);
+
+        startLine = meta.line - buffer;
+        endLine = meta.line + buffer;
         file = `${meta.path}/${meta.file}`;
 
         break;

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -139,7 +139,7 @@ export default class CodeCommand extends SlashCommand {
         if (end < start) [start, end] = [end, start]; // swap if inverted
 
         startLine = start - 1;
-        endLine = end || start + 6;
+        endLine = end;
         file = query;
 
         break;

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -167,7 +167,7 @@ export default class CodeCommand extends SlashCommand {
 
     if (startLine <= 0) startLine = 0;
 
-    const lineSelection = lines.slice(startLine, endLine);
+    const lineSelection = lines.slice(startLine - 1, endLine);
 
     let content = [
       this.generateContentHeader(file, [startLine], [endLine]),
@@ -185,7 +185,6 @@ export default class CodeCommand extends SlashCommand {
       const lines = content.split('\n');
 
       // #region trim location
-      trimTopThisTime = !trimTopThisTime;
       if (subCommand === 'entity' && trimTopThisTime) {
         lines.splice(2, 1);
         actualStart++;
@@ -193,6 +192,7 @@ export default class CodeCommand extends SlashCommand {
         lines.splice(-2, 1);
         actualEnd--;
       }
+      trimTopThisTime = !trimTopThisTime;
       // #endregion
 
       lines[0] = this.generateContentHeader(file, [startLine, actualStart], [endLine, actualEnd]);

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -88,7 +88,7 @@ export default class CodeCommand extends SlashCommand {
       content = lines.join('\n');
     }
 
-    ctx.send({
+    return {
       content,
       components: [
         {
@@ -106,6 +106,6 @@ export default class CodeCommand extends SlashCommand {
           ]
         }
       ]
-    });
+    };
   }
 }

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -172,7 +172,7 @@ export default class CodeCommand extends SlashCommand {
     let content = [
       this.generateContentHeader(file, [startLine], [endLine]),
       '```js',
-      lineSelection.map((line, index) => this.generateCodeLine(line, startLine + index, true)).join('\n'),
+      lineSelection.map((line, index) => this.generateCodeLine(line, startLine + index, endLine, true)).join('\n'),
       '```'
     ].join('\n');
 
@@ -222,8 +222,8 @@ export default class CodeCommand extends SlashCommand {
     };
   }
 
-  private generateCodeLine = (line: string, index: number, includeNumbers: boolean = true) =>
-    [includeNumbers ? `/* ${index + 1} */` : '', line].join(' ');
+  private generateCodeLine = (line: string, index: number, lastLine: number, includeNumbers: boolean = true) =>
+    [includeNumbers ? `/* ${`${index}`.padStart(`${lastLine}`.length, ' ')} */` : '', line].join(' ');
 
   private generateContentHeader = (
     file: string,

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -278,7 +278,7 @@ export default class DocumentationCommand extends SlashCommand {
     };
   }
 
-  private getLinkComponents = (target: [string, string?], typeMeta: FileMeta): ComponentActionRow[] => [
+  private getLinkComponents = (target: [string, string?], meta: FileMeta): ComponentActionRow[] => [
     {
       type: ComponentType.ACTION_ROW,
       components: [
@@ -294,7 +294,7 @@ export default class DocumentationCommand extends SlashCommand {
         {
           type: ComponentType.BUTTON,
           style: ButtonStyle.LINK,
-          url: buildGitHubLink(typeMeta),
+          url: buildGitHubLink(`${meta.path}/${meta.file}`, [meta.line]),
           label: 'Open GitHub',
           emoji: {
             name: '📂'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
 import dotenv from 'dotenv';
 import { SlashCreator, FastifyServer } from 'slash-create';
 import path from 'path';
-import CatLoggr from 'cat-loggr/ts';
+import logger from './util/logger';
 
 let dotenvPath = path.join(process.cwd(), '.env');
 if (path.parse(process.cwd()).name === 'dist') dotenvPath = path.join(process.cwd(), '..', '.env');
 
 dotenv.config({ path: dotenvPath });
 
-const logger = new CatLoggr().setLevel(process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info');
 const creator = new SlashCreator({
   applicationID: process.env.DISCORD_APP_ID,
   publicKey: process.env.DISCORD_PUBLIC_KEY,

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,1 +1,2 @@
 export const SC_RED = 15929905; // color for #F31231
+export const ONE_HOUR = 1000 * 60 * 60;

--- a/src/util/fileCache.ts
+++ b/src/util/fileCache.ts
@@ -1,0 +1,72 @@
+import bent from 'bent';
+import { Collection } from 'slash-create';
+import { ONE_HOUR } from './common';
+
+import { BRANCH, rawContentLink } from './linkBuilder';
+import logger from './logger';
+
+export interface CacheInfo {
+  body: string;
+  fetchedAt: number;
+  ref: string;
+}
+
+const getText = bent('string');
+
+export class FileCache {
+  private cache: Collection<string, CacheInfo> = new Collection();
+  private cacheTime: number = ONE_HOUR; // 1 hour
+  private _interval: NodeJS.Timeout;
+
+  static buildRawURL = (ref: string, path: string) => `${rawContentLink}/${ref}/${path.replace(/#.*/, '')}`;
+
+  constructor() {
+    this._interval = setInterval(() => {
+      const purgeStart = Date.now();
+      for (const [key, entry] of this.cache.entries()) {
+        if (entry.fetchedAt + this.cacheTime > purgeStart) {
+          this.cache.delete(key);
+        }
+      }
+    }, this.cacheTime);
+  }
+
+  destroy() {
+    clearInterval(this._interval);
+    this._interval = null;
+    this.cache.clear();
+  }
+
+  /**
+   *
+   * @param ref What reference does the file we're looking for reside on?
+   * @param path Where is this file located?
+   */
+  has = (path: string, ref: string = BRANCH): boolean => this.cache.has(`${ref}:${path}`);
+
+  get = (path: string, ref: string = BRANCH): CacheInfo => this.cache.get(`${ref}:${path}`);
+
+  async fetch(path: string, ref: string = BRANCH): Promise<CacheInfo> {
+    if (this.has(path, ref)) {
+      const entry = this.get(path, ref);
+      if (entry.fetchedAt + this.cacheTime > Date.now()) {
+        logger.info(`[Cache] Found '${path}' cached at '${ref}'`);
+        return entry;
+      }
+      this.cache.delete(`${ref}:${path}`);
+    }
+
+    const url = FileCache.buildRawURL(ref, path);
+    const body: string = await getText(url);
+
+    if (!body) throw 'Not Found';
+
+    const cacheEntry: CacheInfo = { ref, body, fetchedAt: Date.now() };
+
+    this.cache.set(`${ref}:${path}`, cacheEntry);
+
+    return cacheEntry;
+  }
+}
+
+export default new FileCache();

--- a/src/util/linkBuilder.ts
+++ b/src/util/linkBuilder.ts
@@ -1,5 +1,3 @@
-import { FileMeta } from './metaTypes';
-
 export const BRANCH = `master`; // possiblity to add branch support further in, but i wouldn't see much point if discord keeps changing stuff...
 export const BASE_DOCS_URL = `https://slash-create.js.org/#/docs/main/${BRANCH}`;
 export const REMOTE_LOCATION = `Snazzah/slash-create`;
@@ -8,8 +6,12 @@ export function buildDocsLink(calledType: string, entity: string, scrollTo?: str
   return `${BASE_DOCS_URL}/${calledType}/${entity}${scrollTo ? `?scrollTo=${scrollTo}` : ''}`;
 }
 
-export function buildGitHubLink(fileMeta: FileMeta) {
-  return `https://github.com/${REMOTE_LOCATION}/blob/${BRANCH}/${fileMeta.path}/${fileMeta.file}#L${fileMeta.line}`;
+export function buildGitHubLink(file: string, lineRange: [number, number?]) {
+  const lineString = lineRange
+    .filter(Boolean)
+    .map((n) => `L${n}`)
+    .join('-');
+  return `https://github.com/${REMOTE_LOCATION}/blob/${BRANCH}/${file}#${lineString}`;
 }
 
 export const rawContentLink = `https://raw.githubusercontent.com/${REMOTE_LOCATION}/${BRANCH}`;

--- a/src/util/linkBuilder.ts
+++ b/src/util/linkBuilder.ts
@@ -2,12 +2,14 @@ import { FileMeta } from './metaTypes';
 
 export const BRANCH = `master`; // possiblity to add branch support further in, but i wouldn't see much point if discord keeps changing stuff...
 export const BASE_DOCS_URL = `https://slash-create.js.org/#/docs/main/${BRANCH}`;
-export const BASE_GITHUB_URL = `https://github.com/Snazzah/slash-create/blob/${BRANCH}`;
+export const REMOTE_LOCATION = `Snazzah/slash-create`;
 
 export function buildDocsLink(calledType: string, entity: string, scrollTo?: string) {
   return `${BASE_DOCS_URL}/${calledType}/${entity}${scrollTo ? `?scrollTo=${scrollTo}` : ''}`;
 }
 
 export function buildGitHubLink(fileMeta: FileMeta) {
-  return `${BASE_GITHUB_URL}/${fileMeta.path}/${fileMeta.file}#L${fileMeta.line}`;
+  return `https://github.com/${REMOTE_LOCATION}/blob/${BRANCH}/${fileMeta.path}/${fileMeta.file}#L${fileMeta.line}`;
 }
+
+export const rawContentLink = `https://raw.githubusercontent.com/${REMOTE_LOCATION}/${BRANCH}`;

--- a/src/util/linkBuilder.ts
+++ b/src/util/linkBuilder.ts
@@ -14,4 +14,4 @@ export function buildGitHubLink(file: string, lineRange: [number, number?]) {
   return `https://github.com/${REMOTE_LOCATION}/blob/${BRANCH}/${file}#${lineString}`;
 }
 
-export const rawContentLink = `https://raw.githubusercontent.com/${REMOTE_LOCATION}/${BRANCH}`;
+export const rawContentLink = `https://raw.githubusercontent.com/${REMOTE_LOCATION}`;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,0 +1,3 @@
+import CatLoggr from 'cat-loggr/ts';
+
+export default new CatLoggr().setLevel(process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info');


### PR DESCRIPTION
Resolves #10, closely tied to #6 and #12 with it's `share` option addition.

### New commands

- `/code entity query*$: string around?: int>0 = 3 share?: boolean = false`
  > Content fetched under this command is **trimmed **from both ends**.
  - `query` refers to a documentation entry from `TypeNavigator.typeMap.all`.
  - `around` refers to how many lines it should fetch around the target entry.
  - `share` #6
- `/code lines query*$: string from!: int(>0) end!: int(>0) share?: boolean = false`
  > Content fetched under this command is **trimmed from the bottom only**.
  - `query` refers to a code file it has in memory
  - `start` is where it selects from.
  - `end` is where it selects to.
  - `share` #6

![image](https://user-images.githubusercontent.com/8607699/179730469-5ea1e9ad-b07c-4dfa-a940-451f98779303.png)

### Ongoing considerations

- Caching has not yet been achieved, files are still requested each time the command is run.
- Multi branch queries are not possible yet, and despite the attraction they may have on permalinks - the system currently doesn't know what commit or version it resides on.
- Setting `endLine` to **Infinity** may break *some* things in the long term, depends how willing you are to try and break it.