### PR TITLE
patch: remove forced range adjustment

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -227,7 +227,7 @@ export default class CodeCommand extends SlashCommand {
     file: string,
     [start, actualStart]: [number, number],
     [end, actualEnd]: [number, number]
-  ) => `\`${file}\` - Lines ${this.getAdjustment(start, actualStart + 1)} to ${this.getAdjustment(end, actualEnd)}`;
+  ) => `\`${file}\` - Lines ${this.getAdjustment(start, actualStart)} to ${this.getAdjustment(end, actualEnd)}`;
 
   private getAdjustment = (original: number, actual?: number) =>
     !actual || original === actual ? `\`${original}\`` : `~~\`${original}\`~~ \`${actual}\``;


### PR DESCRIPTION
Removes a forced index adjustment on the trimmed start line that differs from the arguments provided by the user.

Before (SC) and after (Alyx): `/code entity query: SlashCreatorAPI#interactionCallback`

![image](https://user-images.githubusercontent.com/8607699/180573206-d50823b8-eebb-434f-be1a-5dceb296fda5.png)
