### PR TITLE
`query: string` declared as a shared option

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -11,6 +11,8 @@ import {
   SlashCommand,
   SlashCreator
 } from 'slash-create';
+
+import { queryOption, shareOption } from '../util/common';
 import fileCache from '../util/fileCache';
 import { buildGitHubLink } from '../util/linkBuilder';
 import TypeNavigator from '../util/typeNavigator';
@@ -26,24 +28,14 @@ export default class CodeCommand extends SlashCommand {
           description: 'Fetch a file from a type entity.',
           type: CommandOptionType.SUB_COMMAND,
           options: [
-            {
-              name: 'query',
-              description: 'The query to search all entries.',
-              type: CommandOptionType.STRING,
-              autocomplete: true,
-              required: true
-            },
+            queryOption,
             {
               name: 'around',
               description: 'How many lines to retrieve around the entity. (default = 3)',
               min_value: 1,
               type: CommandOptionType.INTEGER
             },
-            {
-              name: 'share',
-              description: 'Share your result with others in the channel. (default = false)',
-              type: CommandOptionType.BOOLEAN
-            }
+            shareOption
           ]
         },
         {
@@ -51,13 +43,7 @@ export default class CodeCommand extends SlashCommand {
           description: 'Fetch specific lines from the source code.',
           type: CommandOptionType.SUB_COMMAND,
           options: [
-            {
-              name: 'query',
-              description: 'The query to search all entries.',
-              type: CommandOptionType.STRING,
-              autocomplete: true,
-              required: true
-            },
+            queryOption,
             {
               name: 'start',
               description: 'Where to select from.',
@@ -72,11 +58,7 @@ export default class CodeCommand extends SlashCommand {
               min_value: 1,
               required: true
             },
-            {
-              name: 'share',
-              description: 'Share your result with others in the channel. (default = false)',
-              type: CommandOptionType.BOOLEAN
-            }
+            shareOption
           ]
         }
       ]

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,12 +2,12 @@ import {
   AutocompleteChoice,
   AutocompleteContext,
   CommandContext,
-  CommandOptionType,
   MessageOptions,
   SlashCommand,
   SlashCreator
 } from 'slash-create';
 
+import { queryOption } from '../util/common';
 import TypeNavigator from '../util/typeNavigator';
 
 export default class SearchCommand extends SlashCommand {
@@ -17,15 +17,7 @@ export default class SearchCommand extends SlashCommand {
     super(creator, {
       name: 'search',
       description: 'Search for a documentation entry.',
-      options: [
-        {
-          name: 'query',
-          description: 'The query to search all entries.',
-          type: CommandOptionType.STRING,
-          autocomplete: true,
-          required: true
-        }
-      ]
+      options: [queryOption]
     });
   }
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -10,6 +10,14 @@ export const shareOption: ApplicationCommandOption = {
   required: false
 };
 
+export const queryOption: ApplicationCommandOption = {
+  name: 'query',
+  description: 'The query to search all entries.',
+  type: CommandOptionType.STRING,
+  autocomplete: true,
+  required: true
+};
+
 export const docsOptionFactory = (option: string): ApplicationCommandOptionAutocompletable => ({
   name: option,
   description: `The ${option} to retrieve.`,


### PR DESCRIPTION
* shared between `/code` and `/search`
* no functional modifications included