### PR TITLE
add `line_numbers` option for `/code`

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -12,7 +12,7 @@ import {
   SlashCreator
 } from 'slash-create';
 
-import { queryOption, shareOption } from '../util/common';
+import { lineNumbersOption, queryOption, shareOption } from '../util/common';
 import fileCache from '../util/fileCache';
 import { buildGitHubLink } from '../util/linkBuilder';
 import TypeNavigator from '../util/typeNavigator';
@@ -35,7 +35,8 @@ export default class CodeCommand extends SlashCommand {
               min_value: 1,
               type: CommandOptionType.INTEGER
             },
-            shareOption
+            shareOption,
+            lineNumbersOption
           ]
         },
         {
@@ -58,7 +59,8 @@ export default class CodeCommand extends SlashCommand {
               min_value: 1,
               required: true
             },
-            shareOption
+            shareOption,
+            lineNumbersOption
           ]
         }
       ]
@@ -81,6 +83,8 @@ export default class CodeCommand extends SlashCommand {
   async run(ctx: CommandContext): Promise<MessageOptions | void | string> {
     const subCommand = ctx.subcommands[0];
     const options = ctx.options[subCommand];
+
+    const shouldHaveLineNumbers = options.line_numbers ?? false;
 
     let file: string = null,
       startLine = 0,
@@ -156,7 +160,9 @@ export default class CodeCommand extends SlashCommand {
     let content = [
       this.generateContentHeader(file, [startLine, actualStart], [endLine, actualEnd]),
       '```js',
-      lineSelection.map((line, index) => this.generateCodeLine(line, startLine + index, endLine, true)).join('\n'),
+      lineSelection
+        .map((line, index) => this.generateCodeLine(line, startLine + index, endLine, shouldHaveLineNumbers))
+        .join('\n'),
       '```'
     ].join('\n');
 

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -102,7 +102,7 @@ export default class CodeCommand extends SlashCommand {
 
         const { meta } = TypeNavigator.findFirstMatch(query);
 
-        const buffer = Math.floor(around / 2);
+        const buffer = Math.trunc(around / 2) + (around % 2);
 
         startLine = meta.line - buffer;
         endLine = meta.line + buffer;

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -203,7 +203,7 @@ export default class CodeCommand extends SlashCommand {
   }
 
   private generateCodeLine = (line: string, index: number, lastLine: number, includeNumbers: boolean) =>
-    (includeNumbers ? `/* ${`${index}`.padStart(`${lastLine}`.length, ' ')} */` : '') + line;
+    (includeNumbers ? `/* ${`${index}`.padStart(`${lastLine}`.length, ' ')} */ ` : '') + line;
 
   private generateContentHeader = (
     file: string,

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -157,6 +157,9 @@ export default class CodeCommand extends SlashCommand {
     let actualEnd = endLine;
     let trimTopThisTime = false;
 
+    if (`${lines[actualStart - 1]}`.trim().length <= 0) actualStart++;
+    if (`${lines[actualEnd - 1]}`.trim().length <= 0) actualEnd--;
+
     let content = [
       this.generateContentHeader(file, [startLine, actualStart], [endLine, actualEnd]),
       '```js',

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -144,32 +144,32 @@ export default class CodeCommand extends SlashCommand {
       };
     }
 
-    if (endLine > lines.length) {
-      startLine -= endLine - startLine;
-      endLine = lines.length;
-    }
-
-    if (startLine <= 1) startLine = 1;
-
-    const lineSelection = lines.slice(startLine - 1, endLine);
-
     let actualStart = startLine;
     let actualEnd = endLine;
-    let trimTopThisTime = false;
+
+    if (actualEnd > lines.length) {
+      actualStart -= actualEnd - actualStart;
+      actualEnd = lines.length;
+    }
+
+    if (actualStart <= 1) actualStart = 1;
 
     if (`${lines[actualStart - 1]}`.trim().length <= 0) actualStart++;
     if (`${lines[actualEnd - 1]}`.trim().length <= 0) actualEnd--;
+
+    const lineSelection = lines.slice(actualStart - 1, actualEnd);
 
     let content = [
       this.generateContentHeader(file, [startLine, actualStart], [endLine, actualEnd]),
       '```js',
       lineSelection
-        .map((line, index) => this.generateCodeLine(line, startLine + index, endLine, shouldHaveLineNumbers))
+        .map((line, index) => this.generateCodeLine(line, actualStart + index, actualEnd, shouldHaveLineNumbers))
         .join('\n'),
       '```'
     ].join('\n');
 
     // #region content trim loop
+    let trimTopThisTime = false;
     while (content.length > 2000) {
       const lines = content.split('\n');
 
@@ -199,7 +199,7 @@ export default class CodeCommand extends SlashCommand {
             {
               type: ComponentType.BUTTON,
               style: ButtonStyle.LINK,
-              url: buildGitHubLink(file, [startLine, actualEnd]),
+              url: buildGitHubLink(file, [actualStart, actualEnd]),
               label: 'Open GitHub',
               emoji: {
                 name: '📂'

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -18,6 +18,12 @@ export const queryOption: ApplicationCommandOption = {
   required: true
 };
 
+export const lineNumbersOption: ApplicationCommandOption = {
+  name: 'line_numbers',
+  description: 'Include line numbers in code response. (default=false)',
+  type: CommandOptionType.BOOLEAN
+};
+
 export const docsOptionFactory = (option: string): ApplicationCommandOptionAutocompletable => ({
   name: option,
   description: `The ${option} to retrieve.`,


### PR DESCRIPTION
closes #17 with the option to include line numbers in the response *defaulting to `false`, similar to #6 and #14*

* default is false
* code will also check for initial empty lines at initial positions and adjust if the line is empty after being trimmed as a string clone
* adjustment variables have been moved further up to track all changes made to a user's options before finalizing the response

![image](https://user-images.githubusercontent.com/8607699/182027738-a5b784ed-763a-4485-8feb-ca02392d86f3.png)
> Attempting to select beyond the range of the file itself, will wrap around as before - but input changes are now noted as adjustments on top of that.