### PR TITLE
feat(/docs *): Docstring description parsing

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -211,6 +211,35 @@ export default class DocumentationCommand extends SlashCommand {
     };
   }
 
+  private addCommonFields(
+    embed: MessageEmbedOptions,
+    targetDescriptor: AnyStructureDescriptor,
+    parentDescriptor: AnyParentDescriptor = targetDescriptor as AnyParentDescriptor
+    // implied parent of current target is itself
+  ): MessageEmbedOptions {
+    // embed = { ...embed };
+
+    if ('description' in targetDescriptor)
+      embed.description = this.parseDocString(targetDescriptor.description, parentDescriptor);
+
+    if ('type' in targetDescriptor && !('params' in targetDescriptor))
+      embed.fields.push({
+        name: 'Type',
+        value: this.resolveType(targetDescriptor.type)
+      });
+
+    if ('params' in targetDescriptor)
+      embed.fields.push(...this.getArgumentEntityFields(parentDescriptor, targetDescriptor));
+
+    if ('returns' in targetDescriptor)
+      embed.fields.push({
+        name: 'Returns',
+        value: this.resolveType(targetDescriptor.returns)
+      });
+
+    return embed;
+  }
+
   private getLinkComponents = (target: [string, string?], meta: FileMeta, isTypedef: boolean): ComponentActionRow[] => [
     {
       type: ComponentType.ACTION_ROW,

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -156,8 +156,10 @@ export default class DocumentationCommand extends SlashCommand {
         try {
           typeMeta = descriptor.meta;
         } catch {
-          ctx.send('Entity was `null`, please check arguments.', { ephemeral: true });
-          return;
+          return {
+            content: 'Entity was `null`, please check arguments.',
+            ephemeral: true
+          };
         }
 
         embed.title = `${descriptor.name}${
@@ -171,17 +173,22 @@ export default class DocumentationCommand extends SlashCommand {
       }
       default: {
         if (options[calledType] === 'null') {
-          // yes... litereal null
-          ctx.send('Invalid query, please check arguments.', { ephemeral: true });
-          return;
+          // yes... literal null
+          return {
+            content: 'Entity was `null`, please check arguments.',
+            ephemeral: true
+          };
         }
 
         const typeEntry = TypeNavigator.findFirstMatch(options.class, options[calledType]) as ChildStructureDescriptor;
         try {
           typeMeta = typeEntry.meta;
         } catch {
-          ctx.send('Entity was `null`, please check arguments.', { ephemeral: true });
-          return;
+          // second catch, in case the parent entry is null
+          return {
+            content: 'Entity not found, please check arguments.',
+            ephemeral: true
+          };
         }
 
         const combinedKey = TypeNavigator.joinKey([options.class, options[calledType]], TypeSymbol[calledType]);

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -180,6 +180,7 @@ export default class DocumentationCommand extends SlashCommand {
           };
         }
 
+        const parentEntry = TypeNavigator.findFirstMatch(options.class) as ClassDescriptor;
         const typeEntry = TypeNavigator.findFirstMatch(options.class, options[calledType]) as ChildStructureDescriptor;
         try {
           typeMeta = typeEntry.meta;
@@ -204,7 +205,7 @@ export default class DocumentationCommand extends SlashCommand {
 
         if ('params' in typeEntry)
           // calledType !== 'prop'
-          embed.fields.push(...this.getArgumentEntityFields(typeEntry, calledType));
+          embed.fields.push(...this.getArgumentEntityFields(parentEntry, typeEntry, calledType));
 
         if ('returns' in typeEntry)
           // calledType === 'method'
@@ -252,8 +253,12 @@ export default class DocumentationCommand extends SlashCommand {
     }
   ];
 
-  private getArgumentEntityFields = (argumentParent: CallableDescriptor, entityType: string): EmbedField[] => {
-    const { params } = argumentParent;
+  private getArgumentEntityFields = (
+    parent: AnyParentDescriptor,
+    argument: CallableDescriptor,
+    entityType: string
+  ): EmbedField[] => {
+    const { params } = argument;
 
     if (!params.length) return [];
 
@@ -263,7 +268,7 @@ export default class DocumentationCommand extends SlashCommand {
         `\`${argument.name}\` - ${this.resolveType(argument.type)} ${
           argument.default ? `= ${argument.default}` : ''
         }`.trim(),
-        `${argument.description}`
+        this.parseDocString(argument.description, parent)
       ].join('\n')
     }));
   };

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -156,7 +156,7 @@ export default class DocumentationCommand extends SlashCommand {
     switch (calledType) {
       case 'class':
       case 'typedef': {
-        const descriptor = TypeNavigator.findFirstMatch(options[calledType]) as ClassDescriptor | TypeDescriptor;
+        const descriptor = TypeNavigator.findFirstMatch(options[calledType]) as AnyParentDescriptor;
         try {
           typeMeta = descriptor.meta;
         } catch {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -138,11 +138,9 @@ export default class DocumentationCommand extends SlashCommand {
       color: SC_RED,
       fields: [],
       timestamp: new Date(ctx.invokedAt),
-      ...(options.share && {
-        footer: {
-          text: titleCase(calledType)
-        }
-      })
+      footer: {
+        text: titleCase(calledType)
+      }
     };
 
     if (options.share) {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -166,11 +166,12 @@ export default class DocumentationCommand extends SlashCommand {
           };
         }
 
+        embed.fields = this.getClassEntityFields(descriptor, 'construct' in descriptor);
         embed.title = `${descriptor.name}${
           'extends' in descriptor ? ` *extends \`${descriptor.extends.join('')}\`*` : ''
         }`;
-        embed.description = this.parseDocString(descriptor.description, descriptor);
-        embed.fields = this.getClassEntityFields(descriptor, 'construct' in descriptor);
+
+        this.addCommonFields(embed, descriptor);
 
         fragments[0] = descriptor.name;
         break;
@@ -199,24 +200,8 @@ export default class DocumentationCommand extends SlashCommand {
         const combinedKey = TypeNavigator.joinKey([options.class, options[calledType]], TypeSymbol[calledType]);
 
         embed.title = combinedKey;
-        embed.description = this.parseDocString(typeEntry.description, parentEntry);
 
-        if ('type' in typeEntry)
-          embed.fields.push({
-            name: 'Type',
-            value: this.resolveType(typeEntry.type)
-          });
-
-        if ('params' in typeEntry)
-          // calledType !== 'prop'
-          embed.fields.push(...this.getArgumentEntityFields(parentEntry, typeEntry, calledType));
-
-        if ('returns' in typeEntry)
-          // calledType === 'method'
-          embed.fields.push({
-            name: 'Returns',
-            value: this.resolveType(typeEntry.returns)
-          });
+        this.addCommonFields(embed, typeEntry, parentEntry);
 
         // exact check, if typeEntry were a class i'd do instance of... maybe
         fragments[0] = options.class;

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -273,33 +273,33 @@ export default class DocumentationCommand extends SlashCommand {
     }));
   };
 
-  private getClassEntityFields = (classEntry: ClassDescriptor | TypeDescriptor, isClass: boolean): EmbedField[] =>
+  private getClassEntityFields = (parent: AnyParentDescriptor, isClass: boolean): EmbedField[] =>
     [
       // ...('construct' in classEntry && this.getArgumentEntityFields(classEntry.construct, 'constructor')),
-      'props' in classEntry && {
-        name: `📏 ${isClass ? this.buildCommandMention('prop') : 'Properties'} (${classEntry.props.length})`,
+      'props' in parent && {
+        name: `📏 ${isClass ? this.buildCommandMention('prop') : 'Properties'} (${parent.props.length})`,
         value:
-          classEntry.props
+          parent.props
             .filter((propEntry) => !propEntry.name.startsWith('_'))
             .map(({ name }) => `\`${name}\``)
             .join('\n') || 'None',
         inline: true
       },
-      'methods' in classEntry && {
-        name: `🔧 ${isClass ? this.buildCommandMention('method') : 'Method'} (${classEntry.methods.length})`,
+      'methods' in parent && {
+        name: `🔧 ${isClass ? this.buildCommandMention('method') : 'Method'} (${parent.methods.length})`,
         value:
-          classEntry.methods
+          parent.methods
             .filter((methodEntry) => methodEntry.access !== 'private' || !methodEntry.name.startsWith('_'))
             // .map((methodEntry) => `[${methodEntry.name}](${buildDocsLink('class', className, methodEntry.name)})`)
             .map(({ name }) => `\`${name}\``)
             .join(`\n`) || 'None',
         inline: true
       },
-      'events' in classEntry && {
-        name: `⌚ ${isClass ? this.buildCommandMention('event') : 'Events'} (${classEntry.events.length})`,
+      'events' in parent && {
+        name: `⌚ ${isClass ? this.buildCommandMention('event') : 'Events'} (${parent.events.length})`,
         value:
-          classEntry.events
-            // implied of the existance as a a class
+          parent.events
+            // implied of the existence as a a class
             // .map((eventEntry) => `[${eventEntry.name}](${buildDocsLink('class', typeEntry.name, eventEntry.name)})`)
             .map(({ name }) => `\`${name}\``)
             .join('\n') || 'None',

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -140,11 +140,15 @@ export default class DocumentationCommand extends SlashCommand {
       timestamp: new Date(ctx.invokedAt),
       ...(options.share && {
         footer: {
-          text: `Requested by ${ctx.user.username}#${ctx.user.discriminator}`,
-          icon_url: ctx.user.avatarURL
+          text: titleCase(calledType)
         }
       })
     };
+
+    if (options.share) {
+      embed.footer.text += ` | Requested by ${ctx.user.username}#${ctx.user.discriminator}`;
+      embed.footer.icon_url = ctx.member ? ctx.member.avatarURL : ctx.user.avatarURL;
+    }
 
     const fragments: [string, string?] = [null, null];
     let typeMeta: FileMeta = null;

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -73,17 +73,14 @@ export default class DocumentationCommand extends SlashCommand {
     const focusedOption: string = ctx.options[command][ctx.focused];
 
     switch (ctx.focused) {
-      case 'class': {
-        let matchingKeys = TypeNavigator.fuzzyFilter(focusedOption, 'class');
+      case 'class':
+      case 'typedef': {
+        let matchingKeys = TypeNavigator.fuzzyFilter(focusedOption, ctx.focused);
 
         if (command === 'event')
           matchingKeys = matchingKeys.filter((value) => 'events' in TypeNavigator.getClassDescriptor(value.string));
 
         return matchingKeys.map((value) => ({ name: value.string, value: value.string }));
-      }
-      case 'typedef': {
-        const results = TypeNavigator.fuzzyFilter(focusedOption, 'typedef');
-        return results.map((value) => ({ name: value.string, value: value.string }));
       }
       case 'event':
       case 'method':

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -77,11 +77,14 @@ export interface ParameterDescriptor {
 
 export interface TypeDescriptor {
   access?: 'private';
-  description: string;
+  description?: string;
   meta: FileMeta;
   name: string;
   see: [];
-  props: MemberDescriptor[];
+  props?: MemberDescriptor[];
+  params?: ParameterDescriptor[];
+  returns?: string[][][];
+  type?: string[][][];
 }
 
 export enum TypeSymbol {

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -108,6 +108,7 @@ export interface TypeOutcome {
   event: EventDescriptor;
 }
 
-export type ChildStructureDescriptor = MethodDescriptor | MemberDescriptor | EventDescriptor;
+export type AnyParentDescriptor = ClassDescriptor | TypeDescriptor;
 export type AnyStructureDescriptor = ChildStructureDescriptor | ClassDescriptor | TypeDescriptor;
 export type CallableDescriptor = MethodDescriptor | EventDescriptor | ClassConstructor;
+export type ChildStructureDescriptor = MethodDescriptor | MemberDescriptor | EventDescriptor;

--- a/src/util/metaTypes.ts
+++ b/src/util/metaTypes.ts
@@ -109,6 +109,10 @@ export interface TypeOutcome {
 }
 
 export type AnyParentDescriptor = ClassDescriptor | TypeDescriptor;
-export type AnyStructureDescriptor = ChildStructureDescriptor | ClassDescriptor | TypeDescriptor;
-export type CallableDescriptor = MethodDescriptor | EventDescriptor | ClassConstructor;
+export type AnyStructureDescriptor = ChildStructureDescriptor | AnyParentDescriptor;
+/**
+ * TypeDescriptor can be a callable entity in rare cases (type Callback = (a: string) => void;), but it's not a class.
+ * <Descriptor>.params is used if <Descriptor>.type is not present (for TypeDescriptor only).
+ */
+export type CallableDescriptor = MethodDescriptor | EventDescriptor | ClassConstructor | TypeDescriptor;
 export type ChildStructureDescriptor = MethodDescriptor | MemberDescriptor | EventDescriptor;


### PR DESCRIPTION
Resolves #22 by introducing better handling of docstring by replacing `@see` and `@link` comments with the links they would have on the [docs site](https://slash-create.js.org/#/docs).

* `/docs class ...` and `/docs typedef ...` autocompletion has been unified to match it's main code sequence.
* `return` statements are used, if it is possible to have the framework handle the response.
* Returned errors, where a literal `null` was found, should now be a little more informative.

