### PR TITLE
patch: remove default log export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { SlashCreator, FastifyServer } from 'slash-create';
 import path from 'path';
-import logger from './util/logger';
+import { logger } from './util/logger';
 import { hashMapToString } from './util/common';
 
 let dotenvPath = path.join(process.cwd(), '.env');
@@ -17,7 +17,7 @@ const creator = new SlashCreator({
   serverHost: '0.0.0.0'
 });
 
-creator.on('debug', (message) => logger.log(message));
+creator.on('debug', (message) => logger.debug(message));
 creator.on('warn', (message) => logger.warn(message));
 creator.on('error', (error) => logger.error(error));
 creator.on('synced', () => logger.info('Commands synced!'));

--- a/src/util/fileCache.ts
+++ b/src/util/fileCache.ts
@@ -3,7 +3,7 @@ import { Collection } from 'slash-create';
 import { ONE_HOUR } from './common';
 
 import { BRANCH, rawContentLink } from './linkBuilder';
-import logger from './logger';
+import { logger } from './logger';
 
 export interface CacheInfo {
   body: string;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,4 +1,7 @@
 import CatLoggr from 'cat-loggr/ts';
 
-// process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info'
-export const logger = new CatLoggr().setLevel('debug').setGlobal();
+//
+export const logger = new CatLoggr()
+  .setLevel(process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info')
+  .setLevel('debug')
+  .setGlobal();

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,3 +1,4 @@
 import CatLoggr from 'cat-loggr/ts';
 
-export default new CatLoggr().setLevel(process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info');
+// process.env.COMMANDS_DEBUG === 'true' ? 'debug' : 'info'
+export const logger = new CatLoggr().setLevel('debug').setGlobal();


### PR DESCRIPTION
* IntelliSense couldn't resolve the logger for files that needed it, since there was no variable to call upon.