### PR TITLE
fix: ensure user has `SEND_MESSAGES` before attempting to respond using the `share` argument

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -191,7 +191,7 @@ export default class CodeCommand extends SlashCommand {
 
     return {
       content,
-      ephemeral: !options.share,
+      ephemeral: ctx.member?.permissions.has('SEND_MESSAGES') && !options.share,
       components: [
         {
           type: ComponentType.ACTION_ROW,

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -215,7 +215,7 @@ export default class DocumentationCommand extends SlashCommand {
 
     return {
       embeds: [embed],
-      ephemeral: !options.share,
+      ephemeral: ctx.member?.permissions.has('SEND_MESSAGES') && !options.share,
       components: this.getLinkComponents(fragments, typeMeta, calledType === 'typedef')
     };
   }


### PR DESCRIPTION
Fixes #23

> **Warning**
> Access to app commands appears to be refused if `SEND_MESSAGES` isn't available. - I guess the main reason I misunderstood it was due to how `USE_APP_COMMANDS` was described and how API Docs describe what users have access to when they have certain permissions granted or revoked (which has been quite unclear to me in some cases in the past - TinkerStorm/interaction-prototypes#4).