### PR TITLE
patch(minor): code block should be TypeScript

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -161,7 +161,7 @@ export default class CodeCommand extends SlashCommand {
 
     let content = [
       this.generateContentHeader(file, [startLine, actualStart], [endLine, actualEnd]),
-      '```js',
+      '```ts',
       lineSelection
         .map((line, index) => this.generateCodeLine(line, actualStart + index, actualEnd, shouldHaveLineNumbers))
         .join('\n'),


### PR DESCRIPTION
Nothing changes in logical terms, but more focused on how hljs behaves when dealing with the code that's provided to the requesting user.