### PR TITLE
refactor(minor): trunc() + % -> round()

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -102,7 +102,7 @@ export default class CodeCommand extends SlashCommand {
 
         const { meta } = TypeNavigator.findFirstMatch(query);
 
-        const buffer = Math.trunc(around / 2) + (around % 2);
+        const buffer = Math.round(around / 2);
 
         startLine = meta.line - buffer;
         endLine = meta.line + buffer;


### PR DESCRIPTION
`Math.round(...)` is pretty much the same as `floor` and `trunc` along with the modulus operation. Although based on the provided logic, it will always be raised to the nearest whole number - leaving no room for _alternating line trimming_.

Line trimming has always been a problem when dealing with Discord's content limit and ensuring a response is always delivered correctly. Another option can be provided as `trim_from` with it's available choices as `Start` and `End` or `Top` and `Bottom`, etc.

https://github.com/slash-create/docs-bot/blob/8109ff639778e5db7f3fd94f52041dbba5324ced/src/commands/code.ts#L176-L185

> That is all it would be affecting, and it would have to be a boolean - or require a rework of it's trimming logic.

