### PR TITLE
feat: natural removal

### DIFF
--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -1,6 +1,7 @@
 import { filter as fuzzyFilter } from 'fuzzy';
 
 import {
+  AnyComponentButton,
   AutocompleteChoice,
   AutocompleteContext,
   ButtonStyle,
@@ -12,6 +13,7 @@ import {
   SlashCreator
 } from 'slash-create';
 
+import { component as deleteComponent } from '../components/delete-repsonse';
 import { lineNumbersOption, queryOption, shareOption } from '../util/common';
 import fileCache from '../util/fileCache';
 import { buildGitHubLink } from '../util/linkBuilder';
@@ -233,23 +235,27 @@ export default class CodeCommand extends SlashCommand {
     }
     // #endregion
 
+    const components: AnyComponentButton[] = [
+      {
+        type: ComponentType.BUTTON,
+        style: ButtonStyle.LINK,
+        url: buildGitHubLink(file, [actualStart, actualEnd]),
+        label: 'Open GitHub',
+        emoji: {
+          name: '📂'
+        }
+      }
+    ];
+
+    if (options.share) components.unshift(deleteComponent);
+
     return {
       content,
       ephemeral: !options.share,
       components: [
         {
           type: ComponentType.ACTION_ROW,
-          components: [
-            {
-              type: ComponentType.BUTTON,
-              style: ButtonStyle.LINK,
-              url: buildGitHubLink(file, [actualStart, actualEnd]),
-              label: 'Open GitHub',
-              emoji: {
-                name: '📂'
-              }
-            }
-          ]
+          components
         }
       ]
     };

--- a/src/commands/debug/message.ts
+++ b/src/commands/debug/message.ts
@@ -29,14 +29,13 @@ export default class MessageDebugCommand extends SlashCommand {
     const origin = 'guild_id' in ctx.data ? ctx.data.guild_id : '@me';
     const target_url = `https://discord.com/channels/${origin}/${ctx.data.channel_id}/${target_id}`;
 
-    this.tryDeferredAdjustment(ctx);
+    if (ctx.targetMessage.author.id !== this.creator.options.applicationID)
+      this.tryDeferredAdjustment(ctx);
 
     return ChatDebugCommand.resolveFinalPayload(rawPayload, 'message', target_url);
   }
 
   private async tryDeferredAdjustment(ctx: CommandContext): Promise<void> {
-    if (ctx.targetMessage.author.id !== this.creator.options.applicationID) return;
-
     const { components } = ctx.targetMessage;
 
     const firstRow = components[0] as ComponentActionRow;

--- a/src/components/delete-repsonse.ts
+++ b/src/components/delete-repsonse.ts
@@ -15,7 +15,7 @@ export const component: ComponentButton = {
   emoji: {
     name: '🗑'
   }
-}
+};
 
 export function hasPermission(context: CommandContext | ComponentContext): boolean {
   if (context.channel.type === 1) return true; // DM

--- a/src/components/delete-repsonse.ts
+++ b/src/components/delete-repsonse.ts
@@ -1,0 +1,29 @@
+import { ButtonStyle, CommandContext, ComponentButton, ComponentContext, ComponentType, SlashCreator } from 'slash-create';
+import { ComponentKeys } from '.';
+
+export const component: ComponentButton = {
+  type: ComponentType.BUTTON,
+  custom_id: ComponentKeys.DELETE_RESPONSE,
+  style: ButtonStyle.DESTRUCTIVE,
+  label: '', // not needed?
+  emoji: {
+    name: '🗑'
+  }
+}
+
+export function hasPermission(context: CommandContext | ComponentContext): boolean {
+  if (context.channel.type === 1) return true; // DM
+  // GROUP_DM - context.channel.type === 3 && context.channel.owner_id === context.user.id
+  if ('targetMessage' in context) {
+    if (context.targetMessage.author.id === context.user.id) return true; // AUTHOR
+  }
+
+  return context.member?.permissions.any(['ADMINISTRATOR', 'MANAGE_MESSAGES']) ?? false; // GUILD
+}
+
+export async function deleteResponse(creator: SlashCreator, context: ComponentContext) {
+  if (!hasPermission(context)) return false;
+
+  await context.acknowledge();
+  await context.delete(context.message.id);
+}

--- a/src/components/delete-repsonse.ts
+++ b/src/components/delete-repsonse.ts
@@ -21,7 +21,7 @@ export function hasPermission(context: CommandContext | ComponentContext): boole
   if (context.channel.type === 1) return true; // DM
   // GROUP_DM - context.channel.type === 3 && context.channel.owner_id === context.user.id
   if ('targetMessage' in context) {
-    if (context.targetMessage.author.id === context.user.id) return true; // AUTHOR
+    if (context.targetMessage.interaction.user.id === context.user.id) return true; // AUTHOR
   }
 
   return context.member?.permissions.any(['ADMINISTRATOR', 'MANAGE_MESSAGES']) ?? false; // GUILD

--- a/src/components/delete-repsonse.ts
+++ b/src/components/delete-repsonse.ts
@@ -1,9 +1,15 @@
-import { ButtonStyle, CommandContext, ComponentButton, ComponentContext, ComponentType, SlashCreator } from 'slash-create';
-import { ComponentKeys } from '.';
+import {
+  ButtonStyle,
+  CommandContext,
+  ComponentButton,
+  ComponentContext,
+  ComponentType,
+  SlashCreator
+} from 'slash-create';
 
 export const component: ComponentButton = {
   type: ComponentType.BUTTON,
-  custom_id: ComponentKeys.DELETE_RESPONSE,
+  custom_id: 'delete-response',
   style: ButtonStyle.DESTRUCTIVE,
   label: '', // not needed?
   emoji: {

--- a/src/components/delete-repsonse.ts
+++ b/src/components/delete-repsonse.ts
@@ -28,8 +28,9 @@ export function hasPermission(context: CommandContext | ComponentContext): boole
 }
 
 export async function deleteResponse(creator: SlashCreator, context: ComponentContext) {
+  await context.acknowledge();
+
   if (!hasPermission(context)) return false;
 
-  await context.acknowledge();
   await context.delete(context.message.id);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-import { SlashCreator } from "slash-create";
+import { SlashCreator } from 'slash-create';
 import { component as deleteComponent, deleteResponse } from './delete-repsonse';
 
 const components = {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,12 @@
 import { SlashCreator } from "slash-create";
-import { deleteResponse } from "./delete-repsonse";
+import { component as deleteComponent, deleteResponse } from './delete-repsonse';
 
-export enum ComponentKeys {
-  DELETE_RESPONSE = "delete-response"
-}
+const components = {
+  [deleteComponent.custom_id]: deleteResponse
+};
 
 export default function registerComponents(creator: SlashCreator) {
-
+  for (const [key, callback] of Object.entries(components)) {
+    creator.registerGlobalComponent(key, (ctx) => callback(creator, ctx));
+  }
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,10 @@
+import { SlashCreator } from "slash-create";
+import { deleteResponse } from "./delete-repsonse";
+
+export enum ComponentKeys {
+  DELETE_RESPONSE = "delete-response"
+}
+
+export default function registerComponents(creator: SlashCreator) {
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import dotenv from 'dotenv';
 import { SlashCreator, FastifyServer } from 'slash-create';
 import path from 'path';
+
 import { hashMapToString } from './util/common';
+import registerComponents from './components';
 
 let dotenvPath = path.join(process.cwd(), '.env');
 if (path.parse(process.cwd()).name === 'dist') dotenvPath = path.join(process.cwd(), '..', '.env');
@@ -29,6 +31,8 @@ creator.on('commandRun', (command, _, ctx) => {
 });
 creator.on('commandRegister', (command) => logger.info(`Registered command ${command.commandName}`));
 creator.on('commandError', (command, error) => logger.error(`Command ${command.commandName}:`, error));
+
+registerComponents(creator);
 
 creator
   .withServer(new FastifyServer())


### PR DESCRIPTION
* `delete` component will retroactively add itself to any message authored by the application - and push subsequent components to the next row until the constraints have been satisfied. It will default to fail if the constraints overflow (5 rows with 5 buttons each... unlikely to break the boundaries for this app, but overflow might be possible).
* `delete` will run for the interaction requestee or anyone with `ADMINISTRATOR` or `MANAGE_MESSAGES`
* `/code *` and `/docs *` will add the component in the leading row position if `share` is active.