### PR TITLE
add `/temporal snowflake {user,channel,role,guild,input}`

### DIFF
--- a/src/util/commandOptions.ts
+++ b/src/util/commandOptions.ts
@@ -2,8 +2,7 @@ import {
   CommandOptionType,
   ApplicationCommandOptionAutocompletable,
   ApplicationCommandOptionLimitedNumber,
-  ApplicationCommandOption,
-  ApplicationCommandOptionSubCommand
+  ApplicationCommandOption
 } from 'slash-create';
 
 export const shareOption: ApplicationCommandOption = {

--- a/src/util/commandOptions.ts
+++ b/src/util/commandOptions.ts
@@ -2,7 +2,8 @@ import {
   CommandOptionType,
   ApplicationCommandOptionAutocompletable,
   ApplicationCommandOptionLimitedNumber,
-  ApplicationCommandOption
+  ApplicationCommandOption,
+  ApplicationCommandOptionSubCommand
 } from 'slash-create';
 
 export const shareOption: ApplicationCommandOption = {


### PR DESCRIPTION
`/temporal snowflake user` (defaulted to self)

![image](https://github.com/slash-create/docs-bot/assets/8607699/24da8fcb-be73-4571-91b9-bb1320bc5a8e)

Currently having the worker, process and increment at the end of the message as I don't know what to do with it. The format of the response follows very similarly to `/temporal now`.

Resolves #60 